### PR TITLE
Fix classify output naming and stabilize bowtie index build

### DIFF
--- a/find_RCRJ_and_classify.py
+++ b/find_RCRJ_and_classify.py
@@ -125,7 +125,12 @@ def classify(
         if i.id in translated_circ_id_list:
             final_trans_circ_seq.append(i)
             print(i)
-    fastqid = rcrj.split('A')[0]
+    base_name = rcrj.replace('.RCRJ_result.csv', '')
+    suffix = 'Aligned.sortedByCoord.out.bam.merge_result'
+    if base_name.endswith(suffix):
+        fastqid = base_name[: -len(suffix)]
+    else:
+        fastqid = base_name
 
     final_trans_circ_seq_name = os.path.join(
         result_file_location, f'{fastqid}.fa'

--- a/map_to_virtual_genomes.py
+++ b/map_to_virtual_genomes.py
@@ -36,7 +36,8 @@ def make_index(thread, genome, ribosome, tmp_file_location, genome_fasta, name):
     subprocess.call(
         'bowtie-build --threads {} {} {}/{}'.format(thread, ribosome, tmp_path, ribo_name),
         shell=True,
-        stdout=False,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.STDOUT,
     )
 
     subprocess.call(


### PR DESCRIPTION
## Summary
- prevent bowtie-build from writing to stdin by redirecting its output safely
- generate deterministic result filenames when classifying RCRJ outputs

## Testing
- python -m compileall make_virtual_genomes.py map_to_virtual_genomes.py find_RCRJ_and_classify.py

------
https://chatgpt.com/codex/tasks/task_e_68e0a6e473108328b80ad9c8e0d73f89